### PR TITLE
F/init - Comment persistence 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,36 @@ The hook will create `.env.example`:
 # Environment variables template
 # Copy this file to .env and fill in your actual values
 
-# Database settings
 DB_HOST=
 DB_PASSWORD=
-API_KEY=  # OpenAI API key
+API_KEY=
+DEBUG=
+```
 
-# App settings
+## Comment Preservation
+
+The `.env.example` file will only preserve comments that start and end with `###`. All other comments will be removed to ensure clarity and consistency.
+
+### Example
+
+Given a `.env` file:
+```bash
+# General settings
+APP_NAME=my_app
+### Important comment ###
+APP_ENV=production
+# Debug settings
+DEBUG=true
+```
+
+The hook will create `.env.example`:
+```bash
+# Environment variables template
+# Copy this file to .env and fill in your actual values
+
+APP_NAME=
+### Important comment ###
+APP_ENV=
 DEBUG=
 ```
 
@@ -151,4 +175,3 @@ env-manager --env-file .env.production --skip-gitignore
 - ✅ **Smart value stripping** - Removes secrets but keeps structure
 - ✅ **Comment preservation** - Maintains inline comments for context
 - ✅ **Flexible file paths** - Works with nested directories and custom names
--

--- a/env_manager.py
+++ b/env_manager.py
@@ -34,16 +34,21 @@ def create_env_example(env_path: Path) -> bool:
         for line in lines:
             stripped = line.strip()
             
-            # Skip empty lines and comments
-            if not stripped or stripped.startswith('#'):
+            # Skip empty lines
+            if not stripped:
+                example_lines.append(line)
+                continue
+            
+            # Keep comments that start and end with ###
+            if stripped.startswith('###') and stripped.endswith('###'):
                 example_lines.append(line)
                 continue
             
             # Handle key=value pairs
             if '=' in stripped:
                 key = stripped.split('=', 1)[0]
-                # Preserve any inline comments
-                comment_match = re.search(r'#.*$', stripped)
+                # Preserve any inline comments that start and end with ###
+                comment_match = re.search(r'#.*###$', stripped)
                 comment = comment_match.group() if comment_match else ''
                 example_lines.append(f"{key}={comment}\n")
             else:

--- a/env_manager.py
+++ b/env_manager.py
@@ -34,23 +34,21 @@ def create_env_example(env_path: Path) -> bool:
         for line in lines:
             stripped = line.strip()
             
-            # Skip empty lines
+            # Skip blank lines
             if not stripped:
-                example_lines.append(line)
                 continue
             
-            # Keep comments that start and end with ###
-            if stripped.startswith('###') and stripped.endswith('###'):
-                example_lines.append(line)
+            # Remove comments that do not start and end with ###
+            if stripped.startswith('#') and not (
+                stripped.startswith('###') and stripped.endswith('###')
+            ):
                 continue
             
             # Handle key=value pairs
             if '=' in stripped:
                 key = stripped.split('=', 1)[0]
-                # Preserve any inline comments that start and end with ###
-                comment_match = re.search(r'#.*###$', stripped)
-                comment = comment_match.group() if comment_match else ''
-                example_lines.append(f"{key}={comment}\n")
+                # Remove secrets by leaving values empty
+                example_lines.append(f"{key}=\n")
             else:
                 # Keep non-standard lines as-is
                 example_lines.append(line)
@@ -137,7 +135,9 @@ def main():
         if not create_env_example(env_path):
             success = False
     else:
-        print(f"ℹ️  No {args.env_file} file found, skipping .env.example creation")
+        print(
+            "ℹ️  No .env file found, skipping .env.example creation"
+        )
     
     # Handle .gitignore
     if not args.skip_gitignore:


### PR DESCRIPTION
1)  Retain comments that **start** & **end** with ###.
2) Remove all comments that start with a single #.
3) Remove all blank lines.  
Example
```env
# This comment will be removed
### This comment will be persisted in the .env.example file ###
```